### PR TITLE
remove console.log

### DIFF
--- a/dist/react-sinatra-ujs.js
+++ b/dist/react-sinatra-ujs.js
@@ -34,13 +34,7 @@ function mountComponents(components) {
     var props = propsJson && JSON.parse(propsJson);
 
     if (typeof component === 'undefined') {
-      var message = 'Cannot find component: ' + componentName;
-
-      if (console && console.log) {
-        console.log('%c[react-sinatra-ujs] %c' + message + ' for element', 'font-weight: bold', '', node);
-      }
-
-      throw new Error('[react-sinatra-ujs] ' + message);
+      throw new Error('Cannot find component: ' + componentName);
     } else {
       _reactDom2.default.render(_react2.default.createElement(component, props), node);
     }

--- a/src/react-sinatra-ujs.js
+++ b/src/react-sinatra-ujs.js
@@ -18,13 +18,7 @@ export function mountComponents(components, configOverrides = {}) {
     const props = propsJson && JSON.parse(propsJson);
 
     if (typeof(component) === 'undefined') {
-      const message = `Cannot find component: ${componentName}`;
-
-      if (console && console.log) {
-        console.log(`%c[react-sinatra-ujs] %c${message} for element`, 'font-weight: bold', '', node);
-      }
-
-      throw new Error(`[react-sinatra-ujs] ${message}`);
+      throw new Error(`Cannot find component: ${componentName}`);
     } else {
       ReactDOM.render(React.createElement(component, props), node);
     }


### PR DESCRIPTION
When `react-sinatra-ujs` build in production environment, `console.log` is unnecessary statement.